### PR TITLE
feat: ensure processed directory exists before saving CSV

### DIFF
--- a/src/analysis.py
+++ b/src/analysis.py
@@ -9,7 +9,10 @@ def main():
     base_dir = os.path.dirname(os.path.abspath(__file__))
 
     raw_data_path = os.path.join(base_dir, "..", "data", "raw", "DENGBR25.csv")
-    output_path = os.path.join(base_dir, "..", "data", "processed", "DENGBR25_processed.csv")
+    processed_dir = os.path.join(base_dir, "..", "data", "processed")
+    output_path = os.path.join(processed_dir, "DENGBR25_processed.csv")
+
+    os.makedirs(processed_dir, exist_ok=True)
 
     df = load_data(raw_data_path)
     df = select_data(df)


### PR DESCRIPTION
# Ensure Processed Directory Exists Before Saving CSV  

## Description  
This PR adds a check to ensure the `processed` directory exists before saving the cleaned dataset. If the directory is missing, it will be created automatically, preventing potential errors when writing the CSV file.  

## Changes  
- Added a check using `os.makedirs(output_dir, exist_ok=True)` to create the `processed` folder if it does not exist.  
- Ensured that the script can run without manual folder creation.  

## How to Test  
1. Delete or rename the `processed` directory if it exists.  
2. Run the script.  
3. Verify that the `processed` directory is created automatically and the CSV file is saved successfully.  

## Checklist  
- [x] The script now handles missing directories gracefully.  
- [x] No breaking changes introduced.  
- [x] Code follows best practices.  